### PR TITLE
feat: Add health check support to redis / two level backend

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 
 The httpcache module provides an easy interface to cache simple http results in Flamingo.
 
-The basic concept is, that there is a so called "cache frontend" - that offers an interface to cache certain types, 
+The basic concept is, that there is a so-called "cache frontend" - that offers an interface to cache certain types, 
 and a "cache backend" that takes care about storing(persisting) the cache entry.
 
 ## Caching HTTP responses from APIs
@@ -29,7 +29,7 @@ injector.Bind((*Frontend)(nil)).AnnotatedWith("myservice").ToInstance(&Frontend{
 
 ## Cache backends
 
-Currently there are the following backends available:
+Currently, there are the following backends available:
 
 ### memory
 
@@ -39,17 +39,17 @@ It is base on the LRU-Strategy witch drops least used entries. For this reason t
 
 ### redis
 
-Is using [redis](https://redis.io/) as an shared inMemory cache.
+Is using [redis](https://redis.io/) as a shared inMemory cache.
 Since all cache-fetched has an overhead to the inMemoryBackend, the redis is a little slower.
-The benefit of redis is the shared storage an the high efficiency in reading and writing keys. Especially if you need scale fast horizontally, it helps to keep your backend-systems healthy.
+The benefit of redis is the shared storage and the high efficiency in reading and writing keys. Especially if you need scale fast horizontally, it helps to keep your backend-systems healthy.
 
-Be ware of using redis (or any other shared cache backend) as a single backend, because of network latency. (have a look at the twoLevelBackend)
+Be aware of using redis (or any other shared cache backend) as a single backend, because of network latency. (have a look at the twoLevelBackend)
 
 
 ### twoLevel
 
 The twoLevelBackend was introduced to get the benefit of the extreme fast memory backend and a shared backend.
-Using the inMemoryBackend in combination with an shared backend, gives you blazing fast responses and helps you to protect your backend in case of fast scaleout-scenarios.
+Using the inMemoryBackend in combination with a shared backend, gives you blazing fast responses and helps you to protect your backend in case of fast scaleout-scenarios.
 
 
 ## Using Cache Factory
@@ -90,3 +90,11 @@ httpcache:
 ```
 
 See `CueConfig` function in module.go for the complete config specification.
+
+Afterward you can use the cache frontend:
+
+```go
+type MyApiClient struct {
+      Cache  *httpcache.Frontend  `inject:"CACHENAME"`
+}
+```

--- a/backendTestCase_test.go
+++ b/backendTestCase_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"flamingo.me/flamingo/v3/core/healthcheck/domain/healthcheck"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"flamingo.me/httpcache"
@@ -44,6 +46,10 @@ func (tc *BackendTestCase) RunTests() {
 
 	if _, ok := tc.backend.(httpcache.TagSupporting); ok {
 		tc.testPurgeTags()
+	}
+
+	if _, ok := tc.backend.(healthcheck.Status); ok {
+		tc.testHealthcheck()
 	}
 }
 
@@ -102,6 +108,17 @@ func (tc *BackendTestCase) testPurgeTags() {
 	tc.shouldNotExist("ONE_KEY")
 	tc.shouldNotExist("ANOTHERKEY_KEY")
 	tc.shouldExist("THIRD_KEY")
+}
+
+func (tc *BackendTestCase) testHealthcheck() {
+	health, ok := tc.backend.(healthcheck.Status)
+	if !ok {
+		tc.t.Fatalf("backend doesnt implement healthcheck.Status interface")
+	}
+
+	alive, details := health.Status()
+	assert.True(tc.t, alive)
+	assert.Equal(tc.t, "", details)
 }
 
 func (tc *BackendTestCase) setEntry(key string, entry httpcache.Entry) {


### PR DESCRIPTION
Since the cache can be a critical piece in the application performance it should be also monitored via the healthcheck. Therefore adding the flamingo healthcheck to the redis backend.