### PR TITLE
fix(redis): Correctly set expiry in seconds, drop usage of deprecated `SETEX`

### DIFF
--- a/backendTestCase_test.go
+++ b/backendTestCase_test.go
@@ -42,6 +42,8 @@ func NewBackendTestCase(t *testing.T, backend httpcache.Backend, tagsInResult bo
 func (tc *BackendTestCase) RunTests() {
 	tc.testSetGetPurge()
 
+	tc.testSetTTL()
+
 	tc.testFlush()
 
 	if _, ok := tc.backend.(httpcache.TagSupporting); ok {
@@ -177,4 +179,13 @@ func (tc *BackendTestCase) buildEntry(content string, tags []string) httpcache.E
 		StatusCode: 0,
 		Body:       []byte(content),
 	}
+}
+
+func (tc *BackendTestCase) testSetTTL() {
+	entry := tc.buildEntry("expires quickly", nil)
+	entry.Meta.GraceTime = time.Now().Add(600 * time.Millisecond)
+	entry.Meta.LifeTime = entry.Meta.GraceTime
+	tc.setEntry("EXPIRED_ENTRY", entry)
+	time.Sleep(1 * time.Second)
+	tc.shouldNotExist("EXPIRED_ENTRY")
 }

--- a/backendTestCase_test.go
+++ b/backendTestCase_test.go
@@ -183,9 +183,9 @@ func (tc *BackendTestCase) buildEntry(content string, tags []string) httpcache.E
 
 func (tc *BackendTestCase) testSetTTL() {
 	entry := tc.buildEntry("expires quickly", nil)
-	entry.Meta.GraceTime = time.Now().Add(600 * time.Millisecond)
+	entry.Meta.GraceTime = time.Now().Add(200 * time.Millisecond)
 	entry.Meta.LifeTime = entry.Meta.GraceTime
 	tc.setEntry("EXPIRED_ENTRY", entry)
-	time.Sleep(1 * time.Second)
+	time.Sleep(300 * time.Millisecond)
 	tc.shouldNotExist("EXPIRED_ENTRY")
 }

--- a/inMemoryBackend_test.go
+++ b/inMemoryBackend_test.go
@@ -2,6 +2,7 @@ package httpcache_test
 
 import (
 	"testing"
+	"time"
 
 	"flamingo.me/httpcache"
 )
@@ -10,7 +11,7 @@ func Test_RunDefaultBackendTestCase_InMemoryBackend(t *testing.T) {
 	t.Parallel()
 
 	f := httpcache.InMemoryBackendFactory{}
-	backend, _ := f.SetConfig(httpcache.MemoryBackendConfig{Size: 100}).SetFrontendName("default").Build()
+	backend, _ := f.SetConfig(httpcache.MemoryBackendConfig{Size: 100}).SetFrontendName("default").SetLurkerPeriod(100 * time.Millisecond).Build()
 
 	testCase := NewBackendTestCase(t, backend, true)
 	testCase.RunTests()

--- a/redisBackend.go
+++ b/redisBackend.go
@@ -217,10 +217,11 @@ func (b *RedisBackend) Set(key string, entry Entry) error {
 	}
 
 	err = conn.Send(
-		"SETEX",
+		"SET",
 		b.createPrefixedKey(key, valuePrefix),
-		int(entry.Meta.GraceTime.Sub(time.Now().Round(time.Second))),
 		buffer,
+		"EX",
+		int(entry.Meta.GraceTime.Sub(time.Now()).Round(time.Second).Seconds()),
 	)
 	if err != nil {
 		b.cacheMetrics.countError("SetFailed")

--- a/redisBackend.go
+++ b/redisBackend.go
@@ -220,14 +220,14 @@ func (b *RedisBackend) Set(key string, entry Entry) error {
 		"SET",
 		b.createPrefixedKey(key, valuePrefix),
 		buffer,
-		"EX",
-		int(time.Until(entry.Meta.GraceTime).Round(time.Second).Seconds()),
+		"PX",
+		time.Until(entry.Meta.GraceTime).Round(time.Millisecond).Milliseconds(),
 	)
 	if err != nil {
 		b.cacheMetrics.countError("SetFailed")
 		b.logger.Error(fmt.Sprintf("Error setting key %q with timeout %v and buffer %v", key, entry.Meta.GraceTime, buffer))
 
-		return fmt.Errorf("redis SETEX failed: %w", err)
+		return fmt.Errorf("redis SET PX failed: %w", err)
 	}
 
 	for _, tag := range entry.Meta.Tags {

--- a/redisBackend.go
+++ b/redisBackend.go
@@ -221,7 +221,7 @@ func (b *RedisBackend) Set(key string, entry Entry) error {
 		b.createPrefixedKey(key, valuePrefix),
 		buffer,
 		"EX",
-		int(entry.Meta.GraceTime.Sub(time.Now()).Round(time.Second).Seconds()),
+		int(time.Until(entry.Meta.GraceTime).Round(time.Second).Seconds()),
 	)
 	if err != nil {
 		b.cacheMetrics.countError("SetFailed")

--- a/twoLevelBackend_test.go
+++ b/twoLevelBackend_test.go
@@ -2,6 +2,7 @@ package httpcache_test
 
 import (
 	"testing"
+	"time"
 
 	"flamingo.me/flamingo/v3/framework/flamingo"
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ import (
 func createInMemoryBackend() httpcache.Backend {
 	return func() httpcache.Backend {
 		f := httpcache.InMemoryBackendFactory{}
-		backend, _ := f.SetConfig(httpcache.MemoryBackendConfig{Size: 100}).SetFrontendName("default").Build()
+		backend, _ := f.SetConfig(httpcache.MemoryBackendConfig{Size: 100}).SetFrontendName("default").SetLurkerPeriod(100 * time.Millisecond).Build()
 
 		return backend
 	}()


### PR DESCRIPTION
Previously the expiration was not properly set in seconds, therefore keys basically never expired. Replaced the SETEX with SET and PX argument since SETEX is deprecated. Therefore we can now have expiries even in milliseconds.

Covered expiration with tests for all backends.